### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,8 @@
 name: Rust
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Humblemonk/dicemaiden-rs/security/code-scanning/2](https://github.com/Humblemonk/dicemaiden-rs/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions`. Since the workflow only builds and tests the code, it does not require write permissions. We will set `contents: read` as the minimal required permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
