### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -6,6 +6,9 @@
 # https://github.com/github/super-linter
 name: Lint Code Base
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Humblemonk/dicemaiden-rs/security/code-scanning/1](https://github.com/Humblemonk/dicemaiden-rs/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow to explicitly define the least privileges required for the task. Since the workflow is focused on linting code, it only needs read access to the repository contents. The `permissions` block should be added at the root level of the workflow to apply to all jobs, as no job-specific permissions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
