### PR TITLE
feat: add Cyberpunk Red game system alias (cpr)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "dicemaiden-rs"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dicemaiden-rs"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2024"
 rust-version = "1.87.0"
 keywords = ["discord", "bot", "dice", "rpg", "tabletop"]

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.4.0] - 2025-07-05
+
+## Added
+
+- Made help commands respond in private message to reduce chat spam
+- Added support for Cyberpunk RED game system
+
 ## [1.3.0] - 2025-07-03
 
 ## Added

--- a/roll_syntax.md
+++ b/roll_syntax.md
@@ -54,6 +54,13 @@
 - `4codr` → 4d10 t8 ie10 r7 (rote quality)
 - `4wod8` → 4d10 f1 t8 (World of Darkness, difficulty 8)
 
+### Cyberpunk Red
+- `cpr` → 1d10 cpr (critical success on 10, critical failure on 1)
+- `cpr + 5` → 1d10 cpr + 5 (with modifier)
+- Critical Success (10): Roll another d10 and add to total
+- Critical Failure (1): Roll another d10 and subtract from total
+- Each explosion happens only once per roll
+
 ### Hero System 5th Edition
 - `2hsn` → 2d6 hsn (normal damage)
 - `3hsk` → 3d6 hsk (killing damage with STUN multiplier)

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -1,3 +1,4 @@
+use crate::commands::CommandResponse; // Import CommandResponse
 use crate::help_text; // Import the shared help text module from src root
 use anyhow::Result;
 use serenity::{
@@ -22,7 +23,7 @@ pub fn register() -> CreateCommand {
         )
 }
 
-pub async fn run(_ctx: &Context, command: &CommandInteraction) -> Result<String> {
+pub async fn run(_ctx: &Context, command: &CommandInteraction) -> Result<CommandResponse> {
     let topic = command
         .data
         .options
@@ -39,5 +40,6 @@ pub async fn run(_ctx: &Context, command: &CommandInteraction) -> Result<String>
         _ => help_text::generate_basic_help(),
     };
 
-    Ok(help_text)
+    // Return as private response
+    Ok(CommandResponse::private(help_text))
 }

--- a/src/dice/aliases.rs
+++ b/src/dice/aliases.rs
@@ -87,6 +87,9 @@ static MM_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"^mm(?:\s+(\d*)([et])(?:\s+(\d*)([et]))?)?$").expect("Failed to compile MM_REGEX")
 });
 
+static CPR_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^cpr(?:\s*([+-]\s*\d+))?$").expect("Failed to compile CPR_REGEX"));
+
 // Use static storage for commonly used alias mappings
 static STATIC_ALIASES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
     let mut aliases = HashMap::new();
@@ -420,6 +423,16 @@ fn expand_parameterized_alias(input: &str) -> Option<String> {
 
     if let Some(result) = expand_marvel_multiverse_alias(input) {
         return Some(result);
+    }
+
+    if let Some(captures) = CPR_REGEX.captures(input) {
+        let modifier = captures.get(1).map(|m| m.as_str().trim()).unwrap_or("");
+
+        if modifier.is_empty() {
+            return Some("1d10 cpr".to_string());
+        } else {
+            return Some(format!("1d10 cpr {modifier}"));
+        }
     }
 
     None

--- a/src/dice/mod.rs
+++ b/src/dice/mod.rs
@@ -56,6 +56,7 @@ pub enum Modifier {
     D6System(u32, String),
     Shadowrun(u32),
     MarvelMultiverse(i32, i32), // (edges, troubles) - already calculated net values
+    CyberpunkRed,
 }
 
 #[derive(Debug, Clone)]

--- a/src/dice/parser.rs
+++ b/src/dice/parser.rs
@@ -1246,6 +1246,7 @@ fn parse_single_modifier(part: &str) -> Result<Modifier> {
         "fudge" | "df" => return Ok(Modifier::Fudge),
         "gb" => return Ok(Modifier::Godbound(false)),
         "gbs" => return Ok(Modifier::Godbound(true)),
+        "cpr" => return Ok(Modifier::CyberpunkRed),
         _ => {}
     }
 

--- a/src/help_text.rs
+++ b/src/help_text.rs
@@ -58,6 +58,9 @@ pub fn generate_alias_help() -> String {
 • `4codr` → 4d10 t8 ie10 r7 (rote quality: reroll failures)
 • `4wod8` → 4d10 f1 t8 (World of Darkness difficulty 8)
 
+**Cyberpunk Red:**
+• `cpr` → 1d10 cpr (critical success on 10, critical failure on 1)
+
 **D&D/Pathfinder:**
 • `dndstats` → 6 4d6 k3 (ability score generation)
 • `attack +5` → 1d20 +5
@@ -71,9 +74,7 @@ pub fn generate_alias_help() -> String {
 **Hero System 5th Edition:**
 • `2hsn` → 2d6 hsn (normal damage)
 • `3hsk` → 3d6 hsk (killing damage)
-• `2hsk1` → 2d6 + 1d3 hsk (alternative fractional notation)
 • `3hsh` → 3d6 hsh (to-hit roll)
-• `hsn`, `hsk`, `hsh` → 1d6 hsn, 1d6 hsk, 3d6 hsh (single die versions)
 
 **Godbound:**
 • `gb` → 1d20 gb (basic d20 with damage chart)
@@ -139,6 +140,7 @@ pub fn generate_system_help() -> String {
 **Other Systems:**
 • `/roll dh 4d10` - Dark Heresy (righteous fury on 10s)
 • `/roll ed15` - Earthdawn step 15 (steps 1-50 available)
+• `/roll cpr + 5` - Skill check with +5 modifier
 
 **Multiple Rolls:**
 • `/roll 4d6 ; 3d8 + 2 ; 1d20` - Up to 4 separate rolls

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,10 +116,7 @@ impl EventHandler for Handler {
             let response = match command.data.name.as_str() {
                 "roll" => commands::roll::run(&ctx, &command).await,
                 "r" => commands::roll::run(&ctx, &command).await,
-                "help" => match commands::help::run(&ctx, &command).await {
-                    Ok(content) => Ok(commands::CommandResponse::public(content)),
-                    Err(e) => Err(e),
-                },
+                "help" => commands::help::run(&ctx, &command).await,
                 "purge" => match commands::purge::run(&ctx, &command).await {
                     Ok(content) => Ok(commands::CommandResponse::public(content)),
                     Err(e) => Err(e),


### PR DESCRIPTION
- Add 'cpr' alias for Cyberpunk Red dice mechanics
- Critical Success (10): explodes up by adding another d10
- Critical Failure (1): explodes down by subtracting another d10
- Each explosion happens only once per roll
- Supports mathematical modifiers: cpr +5, cpr -3, etc.
- Compatible with roll sets, flags, labels, and comments

Implementation:
- Added CyberpunkRed variant to Modifier enum
- Created CPR_REGEX pattern for alias expansion
- Implemented explosion mechanics in roller.rs
- Added comprehensive test suite and documentation
- Updated help text with CPR examples

Usage:
- /roll cpr → Basic CPR skill check
- /roll cpr + 5 → CPR with +5 modifier
- /roll 3 cpr → Roll 3 sets of CPR dice
- /roll (Interface) cpr + 3 ! hacking attempt