### PR TITLE
feat: add Witcher d10 system with indefinite explosions

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Made help commands respond in private message to reduce chat spam
 - Added support for Cyberpunk RED game system
+- Added support for Witcher game system
 
 ## [1.3.0] - 2025-07-03
 

--- a/roll_syntax.md
+++ b/roll_syntax.md
@@ -91,6 +91,13 @@
 - Fantastic: Marvel die (middle) showing 1 becomes 6
 - Edges and troubles cancel each other out
 
+### Witcher d10 System
+- `wit` → 1d10 wit (basic Witcher skill check)
+- `wit + 5` → 1d10 wit with +5 modifier
+- Critical Success (10): Roll another d10 and add to total
+- Critical Failure (1): Roll another d10 and subtract from total
+- Indefinite Explosions: If the additional die also shows 1 or 10, the explosion continues
+
 ### Dark Heresy 2nd Edition
 - `dh 4d10` → 4d10 ie10 (righteous fury on natural 10s)
 

--- a/src/dice/aliases.rs
+++ b/src/dice/aliases.rs
@@ -90,6 +90,9 @@ static MM_REGEX: Lazy<Regex> = Lazy::new(|| {
 static CPR_REGEX: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"^cpr(?:\s*([+-]\s*\d+))?$").expect("Failed to compile CPR_REGEX"));
 
+static WIT_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^wit(?:\s*([+-]\s*\d+))?$").expect("Failed to compile WIT_REGEX"));
+
 // Use static storage for commonly used alias mappings
 static STATIC_ALIASES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
     let mut aliases = HashMap::new();
@@ -432,6 +435,16 @@ fn expand_parameterized_alias(input: &str) -> Option<String> {
             return Some("1d10 cpr".to_string());
         } else {
             return Some(format!("1d10 cpr {modifier}"));
+        }
+    }
+
+    if let Some(captures) = WIT_REGEX.captures(input) {
+        let modifier = captures.get(1).map(|m| m.as_str().trim()).unwrap_or("");
+
+        if modifier.is_empty() {
+            return Some("1d10 wit".to_string());
+        } else {
+            return Some(format!("1d10 wit {modifier}"));
         }
     }
 

--- a/src/dice/mod.rs
+++ b/src/dice/mod.rs
@@ -57,6 +57,7 @@ pub enum Modifier {
     Shadowrun(u32),
     MarvelMultiverse(i32, i32), // (edges, troubles) - already calculated net values
     CyberpunkRed,
+    Witcher,
 }
 
 #[derive(Debug, Clone)]

--- a/src/dice/parser.rs
+++ b/src/dice/parser.rs
@@ -1247,6 +1247,7 @@ fn parse_single_modifier(part: &str) -> Result<Modifier> {
         "gb" => return Ok(Modifier::Godbound(false)),
         "gbs" => return Ok(Modifier::Godbound(true)),
         "cpr" => return Ok(Modifier::CyberpunkRed),
+        "wit" => return Ok(Modifier::Witcher),
         _ => {}
     }
 

--- a/src/help_text.rs
+++ b/src/help_text.rs
@@ -43,7 +43,7 @@ Type `/roll help alias` for game system shortcuts!"#
 }
 
 pub fn generate_alias_help() -> String {
-    r#"🎲 **Game System Aliases** 🎲\
+    r#"🎲 **Game System Aliases** 🎲
 
 **Note:**
 • Additional support can be found on GitHub `https://github.com/Humblemonk/dicemaiden-rs`
@@ -136,6 +136,10 @@ pub fn generate_system_help() -> String {
 • `/roll mm` - Basic 3d6 roll (Marvel die in middle)
 • `/roll mm 2e` - 3d6 with 2 edges
 • `/roll mm 3t` - 3d6 with 3 troubles
+
+**Witcher d10 System:**
+• `wit` → 1d10 wit (basic Witcher skill check)
+• `wit + 5` → 1d10 wit with +5 modifier
 
 **Other Systems:**
 • `/roll dh 4d10` - Dark Heresy (righteous fury on 10s)


### PR DESCRIPTION
- Add 'wit' alias for Witcher TTRPG skill checks (1d10 wit)
- Implement indefinite explosion mechanics on 1s and 10s
- Support mathematical modifiers (wit + 5, wit - 3, etc.)
- Add comprehensive test coverage for all scenarios
- Follow established patterns from Cyberpunk Red implementation
- Compatible with roll sets, flags, comments, and multi-rolls
- Safety limit of 100 explosions prevents infinite loops

Based on R. Talsorian Games' Witcher TTRPG system.