### PR TITLE
feat: Add multiple wrath dice support to Wrath & Glory system

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Made help commands respond in private message to reduce chat spam
 - Added support for Cyberpunk RED game system
 - Added support for Witcher game system
+- Added support for additional wrath dice for wrath and glory
 
 ## [1.3.0] - 2025-07-03
 

--- a/roll_syntax.md
+++ b/roll_syntax.md
@@ -77,6 +77,7 @@
 
 ### Warhammer 40k Wrath & Glory
 - `wng 4d6` → 4d6 with wrath die and success counting
+- `wng w2 4d6` → 4d6 with 2 wrath dice (unbound psyker powers)
 - `wng dn3 5d6` → 5d6 with difficulty 3 (shows PASS/FAIL)
 - `wng 4d6 !soak` → 4d6 soak roll (uses total, not successes)
 - `wng dn4 6d6 !exempt` → 6d6 exempt test without wrath die

--- a/src/dice/mod.rs
+++ b/src/dice/mod.rs
@@ -47,10 +47,10 @@ pub enum Modifier {
     SubtractDice(DiceRoll),         // Subtract dice result
     MultiplyDice(DiceRoll),
     DivideDice(DiceRoll),
-    WrathGlory(Option<u32>, bool), // Wrath & Glory: (difficulty, use_total_instead_of_successes)
-    Godbound(bool),                // gb (false) or gbs (true for straight damage)
-    HeroSystem(HeroSystemType),    // Hero System damage/hit calculations
-    Fudge,                         // df - Fudge dice with symbol display
+    WrathGlory(Option<u32>, bool, u32), // Wrath & Glory: (difficulty, use_total_instead_of_successes)
+    Godbound(bool),                     // gb (false) or gbs (true for straight damage)
+    HeroSystem(HeroSystemType),         // Hero System damage/hit calculations
+    Fudge,                              // df - Fudge dice with symbol display
     DarkHeresy,
     SavageWorlds(u32),
     D6System(u32, String),
@@ -90,6 +90,7 @@ pub struct RollResult {
     pub wng_wrath_die: Option<i32>, // Value of the wrath die (first die)
     pub wng_icons: Option<i32>,     // Count of icons (4-5 results)
     pub wng_exalted_icons: Option<i32>, // Count of exalted icons (6 results)
+    pub wng_wrath_dice: Option<Vec<i32>>, // All wrath dice values (for multiple dice)
     pub suppress_comment: bool,
 }
 
@@ -167,12 +168,29 @@ impl RollResult {
     /// Format the result value (damage, successes, or total)
     fn format_result_value(&self) -> String {
         // Special handling for Wrath & Glory
-        if let (Some(wrath_die), Some(icons), Some(exalted_icons)) =
-            (self.wng_wrath_die, self.wng_icons, self.wng_exalted_icons)
-        {
+        if let (Some(wrath_dice), Some(icons), Some(exalted_icons)) = (
+            self.wng_wrath_dice.as_ref(),
+            self.wng_icons,
+            self.wng_exalted_icons,
+        ) {
             let exalted_value = exalted_icons * 2;
+
+            // Format wrath dice display
+            let wrath_display = if wrath_dice.len() == 1 {
+                format!("Wrath: `{}`", wrath_dice[0])
+            } else {
+                format!(
+                    "Wrath: `[{}]`",
+                    wrath_dice
+                        .iter()
+                        .map(|d| d.to_string())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            };
+
             return format!(
-                "Wrath: `{wrath_die}` | TOTAL - Icons: `{icons}` Exalted Icons: `{exalted_icons}` (Value:{exalted_value})"
+                "{wrath_display} | TOTAL - Icons: `{icons}` Exalted Icons: `{exalted_icons}` (Value:{exalted_value})"
             );
         }
 

--- a/src/help_text.rs
+++ b/src/help_text.rs
@@ -82,11 +82,6 @@ pub fn generate_alias_help() -> String {
 • `gb 3d8` → 3d8 gb (3d8 with damage chart conversion)
 • `gbs 2d10` → 2d10 gbs (2d10 straight damage)
 
-**Warhammer 40k Wrath & Glory:**
-• `wng 4d6` → 4d6 with wrath die and success counting
-• `wng dn3 5d6` → 5d6 with difficulty 3 test (shows PASS/FAIL)
-• `wng 4d6 !soak` → 4d6 without wrath die
-
 **Other Systems:**
 • `3df` → 3d3 fudge (Fudge dice showing +/blank/- symbols)
 • `3wh4+` → 3d6 t4 (Warhammer 40k/AoS)
@@ -129,6 +124,7 @@ pub fn generate_system_help() -> String {
 
 **Wrath & Glory:**
 • `/roll wng 4d6` - Standard roll with wrath die
+• `/roll wng w2 4d6` - Standard roll with 2 wrath dice
 • `/roll wng dn2 4d6` - Difficulty 2 test (shows PASS/FAIL)
 • `/roll wng 4d6 !soak` - Damage/soak roll (no wrath die)
 


### PR DESCRIPTION
- Add wrath dice count parameter (w1-w5) to WrathGlory modifier
- Support transcendent psyker powers with up to 5 wrath dice
- Update alias expansion to always include explicit wrath count
- Maintain backwards compatibility with existing wng syntax
- Add validation for wrath dice count (1-5 range enforced)
- Update roller logic to track multiple wrath dice effects
- Fix clippy warnings (while_let_on_iterator, uninlined_format_args)
- Update test patterns for new 3-field WrathGlory modifier
- Enhance wrath dice complication and glory tracking

Breaking changes:
- WrathGlory modifier now has 3 fields: (difficulty, use_total, wrath_count)
- Alias expansion changed: "wng 4d6" now expands to "4d6 wngw1"

Examples:
- wng w2 4d6 (unbound psyker powers)
- wng w3 dn4 5d6 (transcendent rank 3)
- wng w5 10d6 !soak (maximum rank soak test)