### PR TITLE
feat: add custom target support to storypath dice system

### DIFF
--- a/src/dice/aliases.rs
+++ b/src/dice/aliases.rs
@@ -54,7 +54,7 @@ static SR_REGEX: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"^sr(\d+)$").expect("Failed to compile SR_REGEX"));
 
 static SP_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^sp(\d+)$").expect("Failed to compile SP_REGEX"));
+    Lazy::new(|| Regex::new(r"^sp(\d+)(?:t(\d+))?$").expect("Failed to compile SP_REGEX"));
 
 static YZ_REGEX: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"^(\d+)yz$").expect("Failed to compile YZ_REGEX"));
@@ -356,10 +356,11 @@ fn expand_parameterized_alias(input: &str) -> Option<String> {
         return Some(format!("{count}d6 t5"));
     }
 
-    // Storypath (sp4 -> 4d10 t8 ie10)
+    // Storypath (sp4 -> 4d10 t8 ie10, sp4t7 -> 4d10 t7 ie10)
     if let Some(captures) = SP_REGEX.captures(input) {
         let count = &captures[1];
-        return Some(format!("{count}d10 t8 ie10"));
+        let target = captures.get(2).map_or("8", |m| m.as_str());
+        return Some(format!("{count}d10 t{target} ie10"));
     }
 
     // Year Zero (6yz -> 6d6 t6)

--- a/tests/game_systems_tests.rs
+++ b/tests/game_systems_tests.rs
@@ -115,6 +115,8 @@ fn test_game_systems_comprehensive() {
         ("sp4", true, Some("success"), "Storypath 4 dice"),
         ("sp6", true, Some("success"), "Storypath 6 dice"),
         ("sp8", true, Some("success"), "Storypath 8 dice"),
+        ("sp4t7", true, Some("success"), "Storypath 4 dice target 7"),
+        ("sp5t9", true, Some("success"), "Storypath 5 dice target 9"),
         // Double Digit Dice
         ("dd34", true, None, "Double digit d3*10 + d4"),
         ("dd26", true, None, "Double digit d2*10 + d6"),
@@ -1019,6 +1021,9 @@ fn test_storypath_system_comprehensive() {
         ("sp8", 8, "Storypath 8 dice"),
         ("sp10", 10, "Storypath 10 dice"),
         ("sp12", 12, "Storypath 12 dice"),
+        ("sp4t7", 4, "Storypath 4 dice custom target 7"),
+        ("sp3t6", 3, "Storypath 3 dice custom target 6"),
+        ("sp5t9", 5, "Storypath 5 dice custom target 9"),
     ];
 
     for (alias, expected_dice, description) in storypath_tests {
@@ -1073,7 +1078,7 @@ fn test_storypath_system_comprehensive() {
     }
 
     // Test Storypath with modifiers
-    let storypath_modifier_tests = vec!["sp4 + 2", "sp6 - 1", "sp5 * 2", "sp3 + 1d6"];
+    let storypath_modifier_tests = vec!["sp4 + 2", "sp6 - 1", "sp5 * 2", "sp3 + 1d6", "sp4t7 + 2"];
 
     for test in storypath_modifier_tests {
         let result = parse_and_roll(test);


### PR DESCRIPTION
- Update SP_REGEX to capture optional target: sp4t7 -> 4d10 t7 ie10
- Maintain backward compatibility: sp4 -> 4d10 t8 ie10 (default target 8)
- Add test coverage for custom targets in existing test suite
- Remove erroneous test entries causing compilation errors

Examples:
- sp4 (default): 4d10 t8 ie10
- sp4t7 (custom): 4d10 t7 ie10
- sp6t5 (custom): 6d10 t5 ie10