### PR TITLE
Add D6 Legends (success-based d6 with wild die) alias support:

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Support for Brave New World
 - Support for Conan
 - Support for Silhouette
+- Support for D6 Legends
 
 ## [1.3.0] - 2025-07-03
 

--- a/roll_syntax.md
+++ b/roll_syntax.md
@@ -37,6 +37,14 @@
 - `sw12` → 1d12 trait + 1d6 wild, keep highest, both explode
 - Snake Eyes: Critical failure when both dice roll natural
 
+### D6 Legends (Success-based with Wild Die)
+- `1d6l` → 1d6 t4f1ie6 (wild die only)
+- `8d6l` → 7d6 t4 + 1d6 t4f1ie6 (7 regular + 1 wild)
+- Regular dice: Roll d6, count successes on 4-6
+- Wild die: Roll d6, count successes on 4-6, explode on 6, subtract 1 success for each 1
+- Target number is always 4 (no variable difficulty)
+- Used in DC Universe RPG, Hercules & Xena, and other D6 Legend system games
+
 ### Conan
 - `conan` → 2d20 skill roll (default)
 - `conan4` → 4d20 skill roll (momentum spent for extra dice)

--- a/src/help_text.rs
+++ b/src/help_text.rs
@@ -119,6 +119,12 @@ pub fn generate_system_help() -> String {
 • `/roll 3df` or `/roll 4df` - Fudge dice showing +/blank/- symbols
 • Values: **+** = +1, (blank) = 0, **-** = -1
 
+**D6 Legends System:**
+• Success-based variant of the classic D6 system
+• Regular dice: Count successes on 4-6
+• Wild die: Counts successes on 4-6, explodes on 6, failures (1) subtract 1 success
+• `/roll 8d6l` → 7 regular dice + 1 wild die
+
 **Godbound:**
 • `/roll gb` - d20 with damage chart (1-=0, 2-5=1, 6-9=2, 10+=4)
 • `/roll gbs` - d20 straight damage (bypasses chart)

--- a/tests/game_systems_tests.rs
+++ b/tests/game_systems_tests.rs
@@ -134,6 +134,21 @@ fn test_game_systems_comprehensive() {
         ("2wh3+", true, Some("success"), "Warhammer 2d6 3+"),
         ("3wh4+", true, Some("success"), "Warhammer 3d6 4+"),
         ("5wh5+", true, Some("success"), "Warhammer 5d6 5+"),
+        // D6 Legends
+        ("1d6l", true, Some("success"), "D6 Legends wild die only"),
+        (
+            "8d6l",
+            true,
+            Some("success"),
+            "D6 Legends 7 regular + 1 wild",
+        ),
+        (
+            "12d6l",
+            true,
+            Some("success"),
+            "D6 Legends 11 regular + 1 wild",
+        ),
+        ("0d6l", false, None, "Invalid D6 Legends zero dice"),
     ];
 
     for (system, should_parse, expected_feature, description) in game_systems {
@@ -272,6 +287,9 @@ fn test_alias_expansions() {
         ("-d%", Some("2d10 k1 * 10 + 1d10 - 10")),
         ("dndstats", Some("6 4d6 k3")),
         ("invalid_alias", None),
+        ("1d6l", Some("1d6 t4f1ie6")),
+        ("8d6l", Some("7d6 t4 + 1d6 t4f1ie6")),
+        ("12d6l", Some("11d6 t4 + 1d6 t4f1ie6")),
     ];
 
     for (alias, expected) in alias_tests {
@@ -1555,6 +1573,7 @@ fn test_missing_systems_with_roll_sets() {
         ("4 snm5", "SNM roll sets"),
         ("3 6yz", "Year Zero roll sets"),
         ("2 3wh4+", "Warhammer roll sets"),
+        ("3 5d6l", "D6 Legends roll sets"),
     ];
 
     for (expression, description) in roll_set_tests {


### PR DESCRIPTION
- 1d6l → 1d6 t4f1ie6 (wild die only)
- 8d6l → 7d6 t4 + 1d6 t4f1ie6 (7 regular + 1 wild)
- 12d6l → 11d6 t4 + 1d6 t4f1ie6 (11 regular + 1 wild)

Regular dice count successes on 4-6, wild die explodes on 6 and subtracts 1 success on 1. Used in DC Universe RPG, Hercules & Xena.

- Add D6L_REGEX pattern and expansion logic to aliases.rs
- Update help documentation with D6 Legends mechanics
- Add test coverage to existing comprehensive test arrays
- Update roll_syntax.md with system documentation