### PR TITLE
fix: correct shard connection counting on reconnections

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -273,7 +273,7 @@ async fn main() -> Result<()> {
                     "  This process handles shards {} to {} ({} shards)",
                     start,
                     start + process_shard_count,
-                    process_shard_count
+                    process_shard_count + 1
                 );
                 info!("  Total shards across all processes: {}", total);
                 info!(
@@ -466,7 +466,7 @@ async fn main() -> Result<()> {
             "This process handles shards {} to {} ({} shards)",
             shard_start,
             shard_start + shard_count,
-            shard_count
+            shard_count + 1
         );
         info!("Total shards across all processes: {}", total_shards);
         info!("Use 'pkill dicemaiden-rs' to stop all processes");


### PR DESCRIPTION
Replace unreliable AtomicU32 counter with real-time shard manager queries. The previous implementation only incremented on ready events but never decremented on disconnections, causing inaccurate counts like "17/15 shards ready".

- Remove AtomicU32 connected_shards counter from Handler
- Add get_connected_shard_count() helper function
- Query shard manager directly for actual Connected state count
- Fix clippy warning: return expression directly

Fixes logging accuracy when shards disconnect and reconnect due to heartbeat errors or network issues.