### PR TITLE
fix: correct shard count display in /roll bot-info command

### DIFF
--- a/src/commands/roll.rs
+++ b/src/commands/roll.rs
@@ -238,14 +238,15 @@ async fn generate_bot_info(ctx: &Context) -> Result<String> {
             .ok()
             .and_then(|s| s.parse::<u32>().ok())
             .unwrap_or(0);
-        let shard_count = std::env::var("SHARD_COUNT")
+        let env_shard_count = std::env::var("SHARD_COUNT")
             .ok()
             .and_then(|s| s.parse::<u32>().ok())
             .unwrap_or(1);
+        let actual_shard_count = env_shard_count + 1;
         let total_shards = std::env::var("TOTAL_SHARDS")
             .ok()
             .and_then(|s| s.parse::<u32>().ok())
-            .unwrap_or(shard_count);
+            .unwrap_or(env_shard_count);
 
         // Get current process's server and user counts using helper function
         let (process_server_count, process_user_count) = get_server_and_user_counts(ctx);
@@ -257,8 +258,8 @@ async fn generate_bot_info(ctx: &Context) -> Result<String> {
 • Process Users: ~{}
 • Process Memory: {}"#,
             shard_start,
-            shard_start + shard_count + 1,
-            shard_count + 1,
+            shard_start + env_shard_count,
+            actual_shard_count,
             total_shards,
             process_server_count,
             process_user_count,


### PR DESCRIPTION
- Fix multi-process stats to show correct shard range (0 to 15 instead of 0 to 16)
- Calculate actual_shard_count properly from environment SHARD_COUNT variable
- Ensure consistency with main.rs shard logging fixes
- Resolves incorrect "Process Shards: 0 to 16" display for SHARD_COUNT=15

The bot-info command now correctly shows the actual shard range that matches the process logs and Serenity's shard creation behavior.