### PR TITLE
fix: correct shard connection counting on reconnections attempt #2

### DIFF
--- a/src/commands/roll.rs
+++ b/src/commands/roll.rs
@@ -238,15 +238,14 @@ async fn generate_bot_info(ctx: &Context) -> Result<String> {
             .ok()
             .and_then(|s| s.parse::<u32>().ok())
             .unwrap_or(0);
-        let env_shard_count = std::env::var("SHARD_COUNT")
+        let shard_count = std::env::var("SHARD_COUNT")
             .ok()
             .and_then(|s| s.parse::<u32>().ok())
             .unwrap_or(1);
-        let actual_shard_count = env_shard_count + 1;
         let total_shards = std::env::var("TOTAL_SHARDS")
             .ok()
             .and_then(|s| s.parse::<u32>().ok())
-            .unwrap_or(env_shard_count);
+            .unwrap_or(shard_count);
 
         // Get current process's server and user counts using helper function
         let (process_server_count, process_user_count) = get_server_and_user_counts(ctx);
@@ -258,8 +257,8 @@ async fn generate_bot_info(ctx: &Context) -> Result<String> {
 • Process Users: ~{}
 • Process Memory: {}"#,
             shard_start,
-            shard_start + env_shard_count,
-            actual_shard_count,
+            shard_start + shard_count + 1,
+            shard_count + 1,
             total_shards,
             process_server_count,
             process_user_count,


### PR DESCRIPTION
Replace unreliable AtomicU32 counter with real-time shard manager queries. The previous implementation only incremented on ready events but never decremented on disconnections, causing inaccurate counts like "17/15 shards ready".

- Remove AtomicU32 connected_shards counter from Handler
- Add get_connected_shard_count() helper function
- Query shard manager directly for actual Connected state count
- Fix clippy warning: return expression directly

Fixes logging accuracy when shards disconnect and reconnect due to heartbeat errors or network issues.