### PR TITLE
feat: Add Lasers & Feelings RPG system support

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Support for D6 Legends
 - Support for World of Darkness Homebrew 10s cancel 1s
 - Support for Vampire 5e
+- Support for Laser and Feelings
 - "stability and performance improvements"
 
 ## [1.3.0] - 2025-07-03

--- a/roll_syntax.md
+++ b/roll_syntax.md
@@ -147,6 +147,15 @@
 ### Dark Heresy 2nd Edition
 - `dh 4d10` → 4d10 ie10 (righteous fury on natural 10s)
 
+### Lasers & Feelings
+- `2lf4` → 2d6 target 4 (generic - defaults to Lasers)
+- `2lf4l` → 2d6 target 4 Lasers (success on ≤4)
+- `2lf4f` → 2d6 target 4 Feelings (success on ≥4)
+- **Target Range**: 2-5 (character's number from the game)
+- **LASER FEELINGS**: Rolling exactly the target number gives special insight
+- **Lasers** (science/tech): Count successes on rolls ≤ target
+- **Feelings** (intuition/social): Count successes on rolls ≥ target
+
 ### Other Popular Systems
 - **Shadowrun**: `sr6` → 6d6 t5 (6th edition)
 - **Exalted**: `ex5` → 5d10 t7 t10, `ex5t8` → 5d10 t8 t10

--- a/src/dice/aliases.rs
+++ b/src/dice/aliases.rs
@@ -621,7 +621,7 @@ fn expand_parameterized_alias(input: &str) -> Option<String> {
                 _ => "",    // Generic (let user decide)
             };
 
-            return Some(format!("{}d6 lf{}{}", dice_count, target, lf_type));
+            return Some(format!("{dice_count}d6 lf{target}{lf_type}"));
         }
     }
 

--- a/src/dice/mod.rs
+++ b/src/dice/mod.rs
@@ -27,6 +27,21 @@ pub enum HeroSystemType {
     Hit,     // hsh - to hit roll (3d6 roll-under)
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum LaserFeelingsType {
+    Lasers,   // Roll <= target for success
+    Feelings, // Roll >= target for success
+}
+
+impl fmt::Display for LaserFeelingsType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LaserFeelingsType::Lasers => write!(f, "Lasers"),
+            LaserFeelingsType::Feelings => write!(f, "Feelings"),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum Modifier {
     Add(i32),
@@ -71,6 +86,7 @@ pub enum Modifier {
     ConanCombat(u32), // cd, cd4, cd5 - combat dice interpretation
     Silhouette(u32),
     VampireMasquerade5(u32, u32),
+    LaserFeelings(u32, u32, LaserFeelingsType), // (dice_count, target, roll_type)
 }
 
 #[derive(Debug, Clone)]

--- a/src/dice/roller.rs
+++ b/src/dice/roller.rs
@@ -3386,7 +3386,7 @@ fn apply_laser_feelings_mechanics(
     let all_d6 = result
         .individual_rolls
         .iter()
-        .all(|&roll| roll >= 1 && roll <= 6);
+        .all(|&roll| (1..=6).contains(&roll));
     if !all_d6 {
         return Err(anyhow!("Lasers & Feelings requires d6 dice"));
     }
@@ -3425,19 +3425,12 @@ fn apply_laser_feelings_mechanics(
     result.total = 0;
 
     result.notes.push(format!(
-        "Lasers & Feelings: {}d6 target {} ({})",
-        dice_count, target, roll_type
+        "Lasers & Feelings: {dice_count}d6 target {target} ({roll_type})"
     ));
 
     if laser_feelings_count > 0 {
-        let feeling_text = if laser_feelings_count == 1 {
-            "LASER FEELINGS"
-        } else {
-            "LASER FEELINGS"
-        };
         result.notes.push(format!(
-            "💡 **{}** **{}**! Ask the GM a question!",
-            laser_feelings_count, feeling_text
+            "💡 **{laser_feelings_count}** LASER FEELINGS! Ask the GM a question!"
         ));
     }
 


### PR DESCRIPTION
- New aliases: 2lf4 (generic), 2lf4l (Lasers), 2lf4f (Feelings)
- Success counting: ≤target (Lasers) or ≥target (Feelings)
- LASER FEELINGS: Rolling exactly target gives special insight
- Supports roll sets: 3 2lf4l, dice count 1-20, target 2-5
- Examples: /roll 2lf4l, /roll 3lf3f, /roll 1lf5