### PR TITLE
feat: add Level Up A5E game system with dedicated help

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Support for World of Darkness Homebrew 10s cancel 1s
 - Support for Vampire 5e
 - Support for Laser and Feelings
+- Support Level up D&D 5th Edition
 - "stability and performance improvements"
 
 ## [1.3.0] - 2025-07-03

--- a/roll_syntax.md
+++ b/roll_syntax.md
@@ -73,6 +73,23 @@
 - `+d%` → 2d10 kl1 * 10 + 1d10 - 10 (percentile advantage)
 - `-d%` → 2d10 k1 * 10 + 1d10 - 10 (percentile disadvantage)
 
+### Level Up Advanced 5th Edition (A5E)
+- `a5e +5 ex1` → 1d20+5 + 1d4 (skill check with expertise level 1)
+- `a5e +7 ex2` → 1d20+7 + 1d6 (skill check with expertise level 2)
+- `a5e +3 ex3` → 1d20+3 + 1d8 (skill check with expertise level 3)
+- `+a5e +5 ex1` → 2d20 k1+5 + 1d4 (advantage with expertise)
+- `-a5e +3 ex2` → 2d20 kl1+3 + 1d6 (disadvantage with expertise)
+- `a5e ex1` → 1d20 + 1d4 (expertise without modifier)
+- `a5e +2 ex6` → 1d20+2 + 1d6 (explicit d6 expertise die)
+- `a5e +1 ex8` → 1d20+1 + 1d8 (explicit d8 expertise die)
+- `a5e +3 ex10` → 1d20+3 + 1d10 (house rule: d10 expertise)
+
+**Expertise Die Levels:**
+- `ex1` → d4 (Level 1 expertise)
+- `ex2` → d6 (Level 2 expertise)
+- `ex3` → d8 (Level 3 expertise)
+- `ex4`, `ex6`, `ex8`, `ex10`, `ex12`, `ex20`, `ex100` → Explicit die size
+
 ### World of Darkness / Chronicles of Darkness
 - `4cod` → 4d10 t8 ie10 (Chronicles of Darkness)
 - `4cod8` → 4d10 t8 ie8 (8-again rule)

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -14,12 +14,13 @@ pub fn register() -> CreateCommand {
             CreateCommandOption::new(
                 CommandOptionType::String,
                 "topic",
-                "Help topic (basic, alias, system)",
+                "Help topic (basic, alias, system, a5e)",
             )
             .required(false)
             .add_string_choice("basic", "basic")
             .add_string_choice("alias", "alias")
-            .add_string_choice("system", "system"),
+            .add_string_choice("system", "system")
+            .add_string_choice("a5e", "a5e"),
         )
 }
 
@@ -37,6 +38,7 @@ pub async fn run(_ctx: &Context, command: &CommandInteraction) -> Result<Command
     let help_text = match topic {
         "alias" => help_text::generate_alias_help(),
         "system" => help_text::generate_system_help(),
+        "a5e" => help_text::generate_a5e_help(),
         _ => help_text::generate_basic_help(),
     };
 

--- a/src/commands/roll.rs
+++ b/src/commands/roll.rs
@@ -114,6 +114,7 @@ pub async fn run(ctx: &Context, command: &CommandInteraction) -> Result<CommandR
         "help" => return Ok(CommandResponse::private(help_text::generate_basic_help())),
         "help alias" => return Ok(CommandResponse::private(help_text::generate_alias_help())),
         "help system" => return Ok(CommandResponse::private(help_text::generate_system_help())),
+        "help a5e" => return Ok(CommandResponse::private(help_text::generate_a5e_help())),
         "donate" => return Ok(CommandResponse::public(generate_donate_text())),
         "bot-info" => {
             let bot_info = generate_bot_info(ctx).await?;

--- a/src/help_text.rs
+++ b/src/help_text.rs
@@ -163,3 +163,45 @@ pub fn generate_system_help() -> String {
 Use `/help` for basic syntax and `/help alias` for more shortcuts!"#
         .to_string()
 }
+
+pub fn generate_a5e_help() -> String {
+    r#"🎲 **Level Up: Advanced 5th Edition (A5E) System** 🎲
+
+**Note:**
+• Additional support can be found on GitHub `https://github.com/Humblemonk/dicemaiden-rs`
+• If you experience a bug, please report the issue on GitHub!
+
+A5E uses expertise dice that add to d20 rolls. Multiple expertise sources don't stack as additional dice, but increase the die size:
+
+• **1 source**: +1d4 expertise die
+• **2 sources**: +1d6 expertise die  
+• **3+ sources**: +1d8 expertise die (maximum)
+
+**Concise A5E Syntax (assumes d20):**
+• `a5e +5 ex1` → 1d20+5 + 1d4 (attack +5 with expertise level 1)
+• `a5e ex2` → 1d20 + 1d6 (no modifier, expertise level 2)
+• `a5e -2 ex3` → 1d20-2 + 1d8 (penalty -2, expertise level 3)
+
+**Expertise Levels:**
+• `ex1` = 1d4 (one expertise source)
+• `ex2` = 1d6 (two expertise sources)  
+• `ex3` = 1d8 (three or more sources)
+
+**Explicit Dice Sizes:**
+• `ex4`, `ex6`, `ex8` (standard)
+• `ex10`, `ex12`, `ex20`, `ex100` (house rules)
+
+**Advantage/Disadvantage (only d20 rolled twice):**
+• `+a5e +5 ex1` → 2d20 kh1+5 + 1d4 (advantage + expertise)
+• `-a5e +5 ex1` → 2d20 kl1+5 + 1d4 (disadvantage + expertise)
+• `+a5e ex2` → 2d20 kh1 + 1d6 (advantage, no modifier)
+
+**Common Usage Examples:**
+• `a5e +7 ex1` - Attack roll with proficiency bonus and one expertise source
+• `+a5e +3 ex2` - Advantage on ability check with two expertise sources  
+• `-a5e +5 ex3` - Disadvantage on saving throw with maximum expertise
+• `a5e +12 ex6` - High-level attack with explicit d6 expertise die
+
+Use `/help` for basic syntax and `/help alias` for more shortcuts!"#
+        .to_string()
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1420,3 +1420,57 @@ mod dice_formatting_final_tests {
         println!("Fix activation logic test completed");
     }
 }
+
+#[test]
+fn test_a5e_result_formatting() {
+    use dicemaiden_rs::{format_multiple_results, parse_and_roll};
+
+    // Test A5E result formatting
+    let result = parse_and_roll("a5e +5 ex1").expect("A5E should parse");
+    let formatted = format_multiple_results(&result);
+
+    // Should have proper formatting
+    assert!(formatted.contains("**")); // Bold totals
+    assert!(formatted.contains("`[")); // Dice display
+
+    // Should show the total
+    let total = result[0].total;
+    assert!(formatted.contains(&format!("**{}**", total)));
+}
+
+#[test]
+fn test_a5e_roll_sets_formatting() {
+    use dicemaiden_rs::{format_multiple_results, parse_and_roll};
+
+    // Test A5E roll sets formatting
+    let result = parse_and_roll("3 a5e +5 ex1").expect("A5E roll sets should work");
+    let formatted = format_multiple_results(&result);
+
+    // Should show individual sets
+    assert!(formatted.contains("Set 1"));
+    assert!(formatted.contains("Set 2"));
+    assert!(formatted.contains("Set 3"));
+
+    // Should show combined total
+    assert!(formatted.contains("**Total:"));
+
+    let expected_total: i32 = result.iter().map(|r| r.total).sum();
+    assert!(formatted.contains(&format!("{}**", expected_total)));
+}
+
+#[test]
+fn test_a5e_semicolon_separated() {
+    use dicemaiden_rs::{format_multiple_results, parse_and_roll};
+
+    // Test A5E with semicolon-separated rolls
+    let result = parse_and_roll("a5e +5 ex1; a5e +7 ex2; a5e +3 ex3").expect("Should parse");
+    assert_eq!(result.len(), 3);
+
+    // Each should have original expressions
+    for roll in &result {
+        assert!(roll.original_expression.is_some());
+    }
+
+    let formatted = format_multiple_results(&result);
+    assert!(formatted.contains("Request:")); // Should show individual requests
+}

--- a/tests/performance_tests.rs
+++ b/tests/performance_tests.rs
@@ -47,6 +47,9 @@ fn test_parsing_performance() {
         ("4d6;3d8;2d10;1d20", "Multiple rolls", 100),
         ("100d6 e6 ie k50 r1 t4 +10", "Very complex", 300),
         ("4wod8c + 2", "WoD cancel with modifier", 100),
+        ("a5e +5 ex1", "A5E basic", 100),
+        ("+a5e +7 ex2", "A5E advantage", 200),
+        ("3 a5e +5 ex1", "A5E roll sets", 300),
     ];
 
     // Warmup runs to initialize lazy statics and regex compilation
@@ -54,6 +57,7 @@ fn test_parsing_performance() {
         let _ = parse_and_roll("1d6");
         let _ = parse_and_roll("4cod");
         let _ = parse_and_roll("sw8");
+        let _ = parse_and_roll("a5e +5 ex1");
     }
 
     for (expression, description, max_ms) in performance_cases {
@@ -517,4 +521,27 @@ fn test_cancel_modifier_performance() {
             max_ms
         );
     }
+}
+
+#[test]
+fn test_a5e_alias_performance() {
+    use dicemaiden_rs::dice::aliases;
+    use std::time::Instant;
+
+    // Test that A5E alias expansion is fast
+    let start = Instant::now();
+
+    for _ in 0..1000 {
+        let _ = aliases::expand_alias("a5e +5 ex1");
+        let _ = aliases::expand_alias("+a5e +5 ex1");
+        let _ = aliases::expand_alias("-a5e +5 ex1");
+        let _ = aliases::expand_alias("a5e ex2");
+    }
+
+    let duration = start.elapsed();
+    assert!(
+        duration.as_millis() < 100,
+        "A5E alias expansion should be fast: {}ms",
+        duration.as_millis()
+    );
 }

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -1832,3 +1832,128 @@ fn test_existing_l_patterns_still_rejected() {
         );
     }
 }
+
+#[test]
+fn test_a5e_alias_expansion_unit() {
+    // Test A5E aliases through the public expand_alias function
+    use dicemaiden_rs::dice::aliases;
+
+    // Basic expertise levels
+    assert_eq!(
+        aliases::expand_alias("a5e +5 ex1"),
+        Some("1d20+5 + 1d4".to_string())
+    );
+    assert_eq!(
+        aliases::expand_alias("a5e +5 ex2"),
+        Some("1d20+5 + 1d6".to_string())
+    );
+    assert_eq!(
+        aliases::expand_alias("a5e +5 ex3"),
+        Some("1d20+5 + 1d8".to_string())
+    );
+
+    // Advantage/disadvantage
+    assert_eq!(
+        aliases::expand_alias("+a5e +5 ex1"),
+        Some("2d20 k1+5 + 1d4".to_string())
+    );
+    assert_eq!(
+        aliases::expand_alias("-a5e +5 ex1"),
+        Some("2d20 kl1+5 + 1d4".to_string())
+    );
+
+    // No modifier cases
+    assert_eq!(
+        aliases::expand_alias("a5e ex1"),
+        Some("1d20 + 1d4".to_string())
+    );
+
+    // Explicit dice sizes
+    assert_eq!(
+        aliases::expand_alias("a5e +3 ex4"),
+        Some("1d20+3 + 1d4".to_string())
+    );
+    assert_eq!(
+        aliases::expand_alias("a5e +3 ex6"),
+        Some("1d20+3 + 1d6".to_string())
+    );
+    assert_eq!(
+        aliases::expand_alias("a5e +3 ex8"),
+        Some("1d20+3 + 1d8".to_string())
+    );
+
+    // Invalid patterns - these should return None since they don't match any alias
+    assert_eq!(aliases::expand_alias("a5e +5 ex0"), None);
+    assert_eq!(aliases::expand_alias("a5e +5 ex5"), None);
+    assert_eq!(aliases::expand_alias("a5e +5"), None);
+    assert_eq!(aliases::expand_alias("1d20+5 ex1"), None);
+    assert_eq!(aliases::expand_alias("invalid"), None);
+}
+
+#[test]
+fn test_a5e_case_insensitive_expansion() {
+    // Test that A5E aliases work with different cases
+    use dicemaiden_rs::dice::aliases;
+
+    let case_variants = vec![
+        ("a5e +5 ex1", "1d20+5 + 1d4"),
+        ("A5E +5 EX1", "1d20+5 + 1d4"),
+        ("a5E +5 Ex1", "1d20+5 + 1d4"),
+        ("+a5e +5 ex2", "2d20 k1+5 + 1d6"),
+        ("+A5E +5 EX2", "2d20 k1+5 + 1d6"),
+        ("-a5e +5 ex3", "2d20 kl1+5 + 1d8"),
+        ("-A5E +5 EX3", "2d20 kl1+5 + 1d8"),
+    ];
+
+    for (input, expected) in case_variants {
+        let result = aliases::expand_alias(input);
+        assert_eq!(
+            result,
+            Some(expected.to_string()),
+            "Case variant '{}' should expand correctly",
+            input
+        );
+    }
+}
+
+#[test]
+fn test_a5e_edge_cases() {
+    // Test A5E edge cases through public API
+    use dicemaiden_rs::dice::aliases;
+
+    // Negative modifiers
+    assert_eq!(
+        aliases::expand_alias("a5e -2 ex1"),
+        Some("1d20-2 + 1d4".to_string())
+    );
+
+    // Zero modifier
+    assert_eq!(
+        aliases::expand_alias("a5e +0 ex2"),
+        Some("1d20+0 + 1d6".to_string())
+    );
+
+    // Large modifiers
+    assert_eq!(
+        aliases::expand_alias("a5e +15 ex3"),
+        Some("1d20+15 + 1d8".to_string())
+    );
+
+    // Extended dice sizes (house rules)
+    assert_eq!(
+        aliases::expand_alias("a5e +1 ex10"),
+        Some("1d20+1 + 1d10".to_string())
+    );
+    assert_eq!(
+        aliases::expand_alias("a5e +1 ex12"),
+        Some("1d20+1 + 1d12".to_string())
+    );
+    assert_eq!(
+        aliases::expand_alias("a5e +1 ex20"),
+        Some("1d20+1 + 1d20".to_string())
+    );
+    assert_eq!(
+        aliases::expand_alias("a5e +1 ex100"),
+        Some("1d20+1 + 1d100".to_string())
+    );
+}


### PR DESCRIPTION
- Add a5e +X exN syntax for expertise dice (ex1=d4, ex2=d6, ex3=d8)
- Support advantage/disadvantage with +a5e/-a5e patterns
- Handle explicit dice sizes (ex4, ex6, ex8, ex10, ex12, ex20, ex100)
- Add `/help a5e` and `/roll help a5e` commands for system documentation
- Examples:
 * a5e +5 ex1 → 1d20+5 + 1d4 (skill check with expertise)
 * +a5e ex2 → 2d20 k1 + 1d6 (advantage with expertise)
 * -a5e +3 ex3 → 2d20 kl1+3 + 1d8 (disadvantage with expertise)
 * 3 a5e +5 ex1 → Roll sets with expertise
- Fix keep modifier syntax (k1/kl1 instead of kh1)
- Add comprehensive test coverage and performance benchmarks
- Update roll_syntax.md documentation
- Implements Level Up D&D Expertise Dice Mechanic per discussion