### PR TITLE
fix(roller): resolve Issue #94 - mathematical modifiers double applic…

### DIFF
--- a/src/dice/roller.rs
+++ b/src/dice/roller.rs
@@ -941,11 +941,6 @@ fn apply_special_system_modifiers(
         apply_mathematical_modifiers_to_cpr_total(result, dice)?;
     }
 
-    // Apply mathematical modifiers to special systems if needed
-    if has_special_system && has_math_modifiers {
-        apply_mathematical_modifiers_to_special_systems(result, dice)?;
-    }
-
     Ok(())
 }
 
@@ -3546,43 +3541,4 @@ fn interpret_panic_roll(panic_total: i32) -> String {
         15..=99 => "Heart Attack - You suffer a heart attack and become Broken".to_string(),
         _ => "Catastrophic Panic".to_string(),
     }
-}
-
-fn apply_mathematical_modifiers_to_special_systems(
-    result: &mut RollResult,
-    dice: &DiceRoll,
-) -> Result<()> {
-    // Apply mathematical modifiers to success-based systems like Alien RPG
-    if result.successes.is_some() {
-        for modifier in &dice.modifiers {
-            match modifier {
-                Modifier::Add(value) => {
-                    if let Some(ref mut successes) = result.successes {
-                        *successes += value;
-                    }
-                }
-                Modifier::Subtract(value) => {
-                    if let Some(ref mut successes) = result.successes {
-                        *successes -= value;
-                    }
-                }
-                Modifier::Multiply(value) => {
-                    if let Some(ref mut successes) = result.successes {
-                        *successes *= value;
-                    }
-                }
-                Modifier::Divide(value) => {
-                    if *value == 0 {
-                        return Err(anyhow!("Cannot divide by zero"));
-                    }
-                    if let Some(ref mut successes) = result.successes {
-                        *successes /= value;
-                    }
-                }
-                _ => {} // Skip non-mathematical modifiers
-            }
-        }
-    }
-
-    Ok(())
 }


### PR DESCRIPTION
…ation regression

- Remove redundant apply_mathematical_modifiers_to_special_systems() call that was causing double application of mathematical modifiers to success-counting systems
- Fix test expectations for alien3+2 to validate correct behavior (modifiers affect dice values, not success counts directly)

Fixes #94: Mathematical modifiers before target operators (e.g., 1d12+2 t8) now correctly apply +2 to dice values before success counting, rather than incorrectly adding +2 to the final success count.

Examples now work correctly:
- 1d12+2 t8 → 0-1 successes (was incorrectly 2-3)
- 10 1d12+6 t8 → each set 0-1 successes (was incorrectly 6-7)
- alien3 + 2 → 0-3 successes with +2 applied to dice values

The removed function call was redundant since pre-target mathematical modifiers are already correctly applied in each target case, and post-target modifiers are handled separately for success counts.