### PR TITLE
feat: Add Wild Worlds RPG system support (The Wildsea)

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Enhanced dice randomness with cryptographically secure RNG using multiple entropy sources (OS, time, thread, process, memory)
 - Support for Daggerheart
+- Support for Wild Worlds
 
 ## [1.4.0] - 2025-07-05
 

--- a/roll_syntax.md
+++ b/roll_syntax.md
@@ -222,6 +222,16 @@
 - `dheart` → Hope & Fear dice with display and summary
 - `dheartgm` → GM d20 roll (standard d20)
 
+### Wild Worlds
+- `ww3` → 3d6 ww (basic Wild Worlds roll)
+- `ww4c2` → 4d6 wwc2 (roll 4d6, cut 2 highest before evaluation)
+- **Results based on highest remaining die:**
+  - **6 = Triumph** (complete success)
+  - **4-5 = Conflict** (success with drawback)  
+  - **1-3 = Disaster** (failure with complication)
+- **Twist**: Any doubles/triples add a beneficial twist to the outcome
+- **Cutting**: Remove highest dice before evaluation (simulates difficulty)
+
 ### Other Popular Systems
 - **Shadowrun**: `sr6` → 6d6 t5 (6th edition)
 - **Exalted**: `ex5` → 5d10 t7 t10, `ex5t8` → 5d10 t8 t10

--- a/src/dice/mod.rs
+++ b/src/dice/mod.rs
@@ -94,7 +94,8 @@ pub enum Modifier {
     AlienStress(u32), // Stress dice (count 6s, track 1s for panic, stress level)
     ForgedDark,
     ForgedDarkZero,
-    Daggerheart, // Daggerheart player roll (2d12 Hope/Fear)
+    Daggerheart,             // Daggerheart player roll (2d12 Hope/Fear)
+    WildWorlds(Option<u32>), // Wild Worlds RPG: None=basic, Some(n)=cut n highest dice
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Implement complete Wild Worlds Engine dice mechanics for The Wildsea RPG:

Features:
- Highest-die evaluation system (6=Triumph, 4-5=Conflict, 1-3=Disaster)
- Twist detection on doubles/triples for narrative benefits
- Cutting mechanics to remove highest dice before evaluation
- User-friendly alias expansion (ww3, ww4c2)
- Integration with roll sets, flags, and mathematical modifiers

Syntax:
- `ww3` → Roll 3d6, evaluate highest die
- `ww4c2` → Roll 4d6, cut 2 highest, evaluate remainder
- `3 ww5` → Roll sets with Wild Worlds mechanics
- `ww6 + 2` → Wild Worlds with mathematical modifiers

Implementation:
- Add WildWorlds(Option<u32>) modifier to enum
- Extend alias system with regex-based expansion
- Add apply_wild_worlds_mechanics() with twist detection
- Comprehensive test coverage (50+ test scenarios)
- Full backward compatibility - no breaking changes

The system emphasizes narrative outcomes over numeric totals, perfect for story-driven RPG sessions using The Wildsea RPG.