### PR TITLE
feat: Add EnvFilter support for advanced RUST_LOG filtering

### DIFF
--- a/env.example
+++ b/env.example
@@ -27,7 +27,7 @@ DATABASE_URL=sqlite:main.db
 # GUILD_ID=123456789012345678
 
 # Optional: Rust log level
-# RUST_LOG=warn,dicemaiden_rs=info
+# RUST_LOG=warn,dicemaiden_rs=info,serenity::gateway=info
 
 # =============================================================================
 # SHARDING CONFIGURATION

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,7 +153,13 @@ impl EventHandler for Handler {
 #[tokio::main]
 async fn main() -> Result<()> {
     dotenv::dotenv().ok();
-    tracing_subscriber::fmt::init();
+    use tracing_subscriber::EnvFilter;
+
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
 
     // Initialize database
     let db = Arc::new(database::Database::new().await?);


### PR DESCRIPTION
Replace simple tracing initialization with EnvFilter-based setup to properly parse module-level log filters from the RUST_LOG environment variable.

This enables granular logging control for multi-process sharding, allowing users to filter serenity's gateway logs independently from the bot's logs.

Changes:
- Add tracing_subscriber::EnvFilter import
- Replace fmt::init() with fmt().with_env_filter().init()
- Set default log level to "info" when RUST_LOG is not set

Now supports advanced filtering syntax:
- RUST_LOG=warn,dicemaiden_rs=info,serenity::gateway=debug
- RUST_LOG=info,serenity::gateway=info
- RUST_LOG=error,dicemaiden_rs=info

This is particularly useful for debugging shard connectivity issues without being overwhelmed by logs from other modules.