### PR TITLE
Fixed bug with calculating damge for Hero system killing attacks

### DIFF
--- a/src/dice/aliases.rs
+++ b/src/dice/aliases.rs
@@ -276,7 +276,7 @@ fn process_hero_system_dice(
         }
 
         let dice_expr = if has_fractional {
-            format!("{whole_dice}d6 + 1d3 {dice_type}")
+            format!("{whole_dice}d6 {dice_type} + 1d3")
         } else {
             format!("{whole_dice}d6 {dice_type}")
         };


### PR DESCRIPTION
When using the hsk modifier for the Hero system BODY was being calculated incorrecly if fractional dice were used (ex 3.5hsk). The BODY was being calculated from just the 1d3 roll instead of the sum of all rolls.