### PR TITLE
Include BODY in notes when rolling Hero normal damage

### DIFF
--- a/src/dice/roller.rs
+++ b/src/dice/roller.rs
@@ -1414,8 +1414,34 @@ fn apply_hero_system_calculation(
 ) -> Result<()> {
     match hero_type {
         HeroSystemType::Normal => {
+            let mut body_damage: i32 = 0;
+            let stun_damage: i32 = result.total;
+            for group in result.dice_groups.iter() {
+                if group._description.ends_with("d3") {
+                    // There should only be a single d3 rolled for damage, so use the first one found
+                    match group.rolls[0] {
+                        3 => body_damage += 1,
+                        2 => {
+                            if rng.random_bool(0.5) {
+                                body_damage += 1;
+                            }
+                        } // 50% chance of a 2 adding body
+                        _ => (),
+                    }
+                } else {
+                    for roll in group.rolls.iter() {
+                        match roll {
+                            6 => body_damage += 2,
+                            2..=5 => body_damage += 1,
+                            _ => (),
+                        }
+                    }
+                }
+            }
             // Normal damage - just use the total as-is
-            result.notes.push("Normal damage".to_string());
+            result.notes.push(format!(
+                "Normal damage: {body_damage} BODY, {stun_damage} STUN"
+            ));
         }
         HeroSystemType::Killing => {
             // Killing damage: BODY = dice total, STUN = BODY × multiplier (1d3)


### PR DESCRIPTION
Include information about BODY done when rolling normal damage for Hero system. Valid Hero damage dice for a normal damage roll are d6 and d3 (and sometimes a single pip, +1). When calculating BODY for a d6, a 6 counts as 2 BODY, a 1 as 0 BODY, and everthing else is 1 BODY. For a d3 a 3 counts as 1 BODY, a 2 has a 50% chance of causing 1 BODY, and a 1 is 0 BODY. A single pip (+1) never causes BODY.