### PR TITLE
feat(plotweaver): add plot die

### DIFF
--- a/roll_syntax.md
+++ b/roll_syntax.md
@@ -287,6 +287,7 @@
 - **Storypath**: `sp4` → 4d10 t8 ie10, `sp4t6` → 4d10 t6 ie10 (custom target)
 - **Sunsails**: `snm5` → 5d6 ie6 t4
 - **D6 System**: `d6s4` → 4d6 + 1d6 ie
+- **Plotweaver/Cosmerer RPG**: `dp` → d6 plot (Plot Die)
 
 ## System-Specific Examples
 

--- a/src/dice/aliases.rs
+++ b/src/dice/aliases.rs
@@ -192,6 +192,9 @@ static MNM_REGEX: Lazy<Regex> =
 static MS_REGEX: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"^([+-])?ms(\d+)?$").expect("Failed to compile MS_REGEX"));
 
+static DP_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^(\d+)dp$").expect("Failed to compile DP_REGEX"));
+
 // Use static storage for commonly used alias mappings
 static STATIC_ALIASES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
     let mut aliases = HashMap::new();
@@ -236,6 +239,7 @@ static STATIC_ALIASES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| 
     aliases.insert("ww6c1", "6d6 wwc1");
     aliases.insert("ww6c2", "6d6 wwc2");
     aliases.insert("ww6c3", "6d6 wwc3");
+    aliases.insert("dp", "1d6 plot");
     aliases
 });
 
@@ -557,6 +561,12 @@ fn expand_parameterized_alias(input: &str) -> Option<String> {
             }
             _ => return None,
         });
+    }
+
+    // Plot dice (3dp -> 3d6 plot)
+    if let Some(captures) = DP_REGEX.captures(input) {
+        let count = &captures[1];
+        return Some(format!("{count}d6 plot"));
     }
 
     // 1. Handle ex5t8ds10 → 5d10 t8ds10 (custom target + double, long form)

--- a/src/dice/mod.rs
+++ b/src/dice/mod.rs
@@ -98,6 +98,7 @@ pub enum Modifier {
     WildWorlds(Option<u32>),       // Wild Worlds RPG: None=basic, Some(n)=cut n highest dice
     Mothership(Option<u32>, bool), // Mothership RPG: (stat_target, is_advantage) - roll-under with doubles as crits
     MutantsMasterminds,            // Mutants & Masterminds degree system
+    PlotDie,                       // Plotweaver system plot die
 }
 
 #[derive(Debug, Clone)]
@@ -139,6 +140,7 @@ pub struct RollResult {
     pub fitd_outcome: Option<String>, // "SUCCESS", "PARTIAL SUCCESS", "FAILURE", "CRITICAL SUCCESS"
     pub fitd_result: Option<String>,  // Description of what the outcome means
     pub fitd_highest_die: Option<i32>, // The key die used for the result
+    pub plot_symbols: Option<Vec<String>>, // Store Plot dice symbols
 }
 
 impl RollResult {
@@ -146,6 +148,11 @@ impl RollResult {
     fn format_dice_display(&self) -> String {
         // Special handling for Fudge dice
         if let Some(ref symbols) = self.fudge_symbols {
+            return format!("`[{}]`", symbols.join(", "));
+        }
+
+        // Special handling for a Plot die
+        if let Some(ref symbols) = self.plot_symbols {
             return format!("`[{}]`", symbols.join(", "));
         }
 

--- a/src/dice/parser.rs
+++ b/src/dice/parser.rs
@@ -960,7 +960,8 @@ fn split_combined_modifiers(input: &str) -> Result<Vec<String>> {
             (r"^(aliens\d+)", "alien stress"),   // aliens1, aliens2, etc.
             (r"^(wwc\d+)", "wild worlds cut"),   // wwc2, wwc3, etc. (before basic ww)
             (r"^(ms\d+[ad]?|ms[ad]?|ms)", "mothership"),
-            (r"^(ww)", "wild worlds"), // ww (basic)
+            (r"^(ww)", "wild worlds"),           // ww (basic)
+            (r"^(plot|dp)", "plotweaver"),       // plot, dp
         ];
 
         let mut found_match = false;
@@ -1343,6 +1344,8 @@ fn is_modifier_start(input: &str) -> bool {
         r"^aliens\d+", // Alien stress modifiers: aliens1, aliens2, etc.
         r"^fitd$",     // Forged in the Dark (exact)
         r"^fitd0$",    // FitD zero dice (exact)
+        r"^plot$",     // Plot dice (exact)
+        r"^dp$",       // Plot dice (exact)
     ];
 
     // Check if the input starts with any of these patterns
@@ -1507,6 +1510,7 @@ fn parse_single_modifier(part: &str) -> Result<Modifier> {
         "mnm" => return Ok(Modifier::MutantsMasterminds),
         "c" => return Ok(Modifier::Cancel),
         "ww" => return Ok(Modifier::WildWorlds(None)),
+        "plot" | "dp" => return Ok(Modifier::PlotDie),
         _ => {}
     }
 

--- a/src/dice/roller.rs
+++ b/src/dice/roller.rs
@@ -131,6 +131,7 @@ pub fn roll_dice(dice: DiceRoll) -> Result<RollResult> {
         fitd_outcome: None,
         fitd_result: None,
         fitd_highest_die: None,
+        plot_symbols: None,
     };
 
     // Normal dice rolling flow for non-special systems
@@ -833,6 +834,9 @@ fn apply_special_system_modifiers(
             Modifier::Mothership(_, _) => {
                 // Mothership is handled in the main roll_dice function
                 // Don't process it here
+            }
+            Modifier::PlotDie => {
+                apply_plot_die_conversion(result)?;
             }
 
             // Skip mathematical modifiers here - they're handled by target processing or post-target processing
@@ -1569,6 +1573,7 @@ fn handle_savage_worlds_roll(dice: DiceRoll, rng: &mut impl Rng) -> Result<RollR
         fitd_outcome: None,
         fitd_result: None,
         fitd_highest_die: None,
+        plot_symbols: None,
     };
 
     // Find the Savage Worlds modifier
@@ -1758,6 +1763,7 @@ fn handle_d6_system_roll(dice: DiceRoll, rng: &mut impl Rng) -> Result<RollResul
         fitd_outcome: None,
         fitd_result: None,
         fitd_highest_die: None,
+        plot_symbols: None,
     };
 
     // Find the D6 System modifier
@@ -1925,6 +1931,7 @@ fn handle_marvel_multiverse_roll(dice: DiceRoll, rng: &mut impl Rng) -> Result<R
         fitd_outcome: None,
         fitd_result: None,
         fitd_highest_die: None,
+        plot_symbols: None,
     };
 
     // Find the Marvel Multiverse modifier
@@ -2448,6 +2455,7 @@ pub fn handle_brave_new_world_roll(dice: DiceRoll, rng: &mut impl Rng) -> Result
         fitd_outcome: None,
         fitd_result: None,
         fitd_highest_die: None,
+        plot_symbols: None,
     };
 
     let pool_size = dice.count;
@@ -2582,6 +2590,7 @@ fn handle_conan_skill_roll(dice: DiceRoll, rng: &mut impl Rng) -> Result<RollRes
         fitd_outcome: None,
         fitd_result: None,
         fitd_highest_die: None,
+        plot_symbols: None,
     };
 
     // Find the ConanSkill modifier to get dice count
@@ -2773,6 +2782,7 @@ fn handle_conan_combat_roll(dice: DiceRoll, rng: &mut impl Rng) -> Result<RollRe
         fitd_outcome: None,
         fitd_result: None,
         fitd_highest_die: None,
+        plot_symbols: None,
     };
 
     // Find the ConanCombat modifier to get dice count
@@ -2897,6 +2907,7 @@ fn handle_silhouette_roll(dice: DiceRoll, rng: &mut impl Rng) -> Result<RollResu
         fitd_outcome: None,
         fitd_result: None,
         fitd_highest_die: None,
+        plot_symbols: None,
     };
 
     // Roll the dice pool
@@ -3288,6 +3299,7 @@ fn handle_vtm5_roll(
         fitd_outcome: None,
         fitd_result: None,
         fitd_highest_die: None,
+        plot_symbols: None,
     };
 
     let regular_dice = pool_size - hunger_dice;
@@ -3755,6 +3767,36 @@ fn apply_wild_worlds_mechanics(result: &mut RollResult, cut_count: Option<u32>) 
     Ok(())
 }
 
+fn apply_plot_die_conversion(result: &mut RollResult) -> Result<()> {
+    let mut symbols = Vec::new();
+    let mut plot_total = 0;
+
+    for &roll in &result.kept_rolls {
+        let (symbol, value) = match roll {
+            1 => ("COMPLICATION (+2)", 2),
+            2 => ("COMPLICATION (+4)", 4),
+            3 | 4 => ("_", 0), // Blank
+            5 | 6 => ("OPPORTUNITY", 0),
+            _ => return Err(anyhow!("Invalid Plot die value: {}", roll)),
+        };
+        symbols.push(symbol.to_string());
+        plot_total += value;
+    }
+
+    result.plot_symbols = Some(symbols);
+
+    let original_dice_total: i32 = result.kept_rolls.iter().sum();
+    let plot_adjustment = plot_total - original_dice_total;
+    result.total += plot_adjustment;
+
+    result.notes.push(
+        "Plot dice: 1=(COMPLICATION (+2)); 2=(COMPLICATION (+2)); 3, 4=(_); 5, 6=(OPPORTUNITY)"
+            .to_string()
+    );
+
+    Ok(())
+}
+
 /// Helper function to detect matching dice values (for twist detection)
 fn has_matching_dice(dice: &[i32]) -> bool {
     for i in 1..=6 {
@@ -3797,6 +3839,7 @@ pub fn handle_mutants_masterminds_roll(dice: DiceRoll, rng: &mut impl Rng) -> Re
         fitd_outcome: None,
         fitd_result: None,
         fitd_highest_die: None,
+        plot_symbols: None,
     };
 
     // Roll the dice
@@ -4011,6 +4054,7 @@ fn handle_mothership_roll(dice: DiceRoll, rng: &mut impl Rng) -> Result<RollResu
         fitd_outcome: None,
         fitd_result: None,
         fitd_highest_die: None,
+        plot_symbols: None,
     };
 
     // Add descriptive notes

--- a/src/help_text.rs
+++ b/src/help_text.rs
@@ -99,6 +99,7 @@ pub fn generate_alias_help() -> String {
 • `cpr` → Cyberpunk Red 1d10 cpr (critical success on 10, critical failure on 1)
 • `conan3` → 3d20 conan (3d20 skill roll)
 • `sil#` → Silhouette system: roll #d6, keep highest, extra 6s add +1 (e.g., sil3, sil5)
+• `dp` → d6 plot (Plot dice showing OPPORTUNITY/blank/COMPLICATION(+2/4) symbols)
 
 Use `/roll help system` for specific examples!"#
         .to_string()
@@ -151,6 +152,10 @@ pub fn generate_system_help() -> String {
 **Brave New World**
 • `bnw3` → 3d6 pool, take highest die, 6s explode into new results
 • `bnw5 + 2` → 5-die pool with +2 modifier (applied after taking highest)
+
+**Plotweaver/Cosmere RPG:**
+• `/roll dp` or `/roll 1dp` - Plot dice showing OPPORTUNITY/blank/COMPLICATION(+2/4) symbols
+• Values: **OPPORTUNITY** = 0, (blank) = 0, **COMPLICATION (+2)** = 2
 
 **Other Systems:**
 • `/roll dh 4d10` - Dark Heresy (righteous fury on 10s)

--- a/tests/game_systems_tests.rs
+++ b/tests/game_systems_tests.rs
@@ -197,6 +197,8 @@ fn test_game_systems_comprehensive() {
         ("a5e +3 ex3", true, Some("total"), "A5E expertise level 3"),
         ("+a5e +5 ex1", true, Some("total"), "A5E with advantage"),
         ("-a5e +5 ex1", true, Some("total"), "A5E with disadvantage"),
+        // Plotweaver/Cosmere RPG
+        ("dp", true, Some("total"), "Plotweaver, plain plot die roll"),
     ];
 
     for (system, should_parse, expected_feature, description) in game_systems {
@@ -522,6 +524,34 @@ fn test_godbound_damage_mechanics() {
         .iter()
         .any(|note| note.contains("Straight damage"));
     assert!(has_straight_note, "Should have straight damage note");
+}
+
+#[test]
+fn test_plotweaver_plot_dice_mechanics() {
+    // Test plot dice symbols and ranges
+    let result = parse_and_roll("4dp").unwrap();
+    assert_eq!(result.len(), 1);
+
+    // Should have fudge symbols
+    assert!(result[0].plot_symbols.is_some());
+
+    // Should be in valid range (0 to 16 for 4dp)
+    assert!(result[0].total >= 0 && result[0].total <= 16);
+
+    let symbols = result[0].plot_symbols.as_ref().unwrap();
+    assert_eq!(symbols.len(), 4);
+
+    // Each symbol should be OPPORTUNITY, COMPLICATION (+X), or blank
+    for symbol in symbols {
+        assert!(
+            symbol == "OPPORTUNITY"
+                || symbol == "COMPLICATION (+2)"
+                || symbol == "COMPLICATION (+4)"
+                || symbol == "_",
+            "Wrong value: {}",
+            symbol
+        );
+    }
 }
 
 // ============================================================================

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -443,6 +443,7 @@ fn test_help_system_integration() {
     let system_help = help_text::generate_system_help();
     assert!(system_help.contains("Game System Examples"));
     assert!(system_help.contains("Fudge/FATE"));
+    assert!(system_help.contains("Plotweaver/Cosmere RPG"));
     assert!(system_help.len() > 100);
 }
 

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -146,6 +146,7 @@ fn test_mathematical_modifiers_with_game_systems() {
         // Special systems
         ("gb + 1d4", false, "Godbound damage with addition"),
         ("4df + 2", false, "Fudge dice with addition"),
+        ("2dp + 2", false, "Plot dice with addition"),
     ];
 
     for (expression, is_success_based, description) in system_modifier_tests {
@@ -187,7 +188,9 @@ fn test_mathematical_modifiers_with_game_systems() {
 
         // All systems should produce some output
         assert!(
-            !roll.individual_rolls.is_empty() || roll.fudge_symbols.is_some(),
+            !roll.individual_rolls.is_empty()
+                || roll.fudge_symbols.is_some()
+                || roll.plot_symbols.is_some(),
             "System modifier test '{}' should produce dice output: {}",
             expression,
             description


### PR DESCRIPTION
Hi there,

I'm running Cosmere RPG games in discord and having a blast using your app.
The thing I'm missing is a special die that is used in the system, called plot die.
It's a simple d6 with proper mapping (a bit similar to how fudge die works in fate):
<img width="1073" height="410" alt="image" src="https://github.com/user-attachments/assets/94b3ed48-522d-4424-a473-fd42707060fd" />

I've setup the code for it in this PR. It's my first time with rust so I hope I did not do anything very wrong.
I've run test suite and tried it out on test discord app so it should be fine (fingers crossed).

Thanks for your work!